### PR TITLE
Fix frequency enum mismatch

### DIFF
--- a/tests/unit/validators/subscription.validators.test.js
+++ b/tests/unit/validators/subscription.validators.test.js
@@ -2,8 +2,7 @@ import { validationResult } from 'express-validator';
 import {
   createSubscriptionValidators,
   updateSubscriptionValidators,
-  subscriptionIdValidator,
-  getSubscriptionsQueryValidators
+  subscriptionIdValidator
 } from '../../../validators/subscription.validators.js';
 
 /**

--- a/validators/subscription.validators.js
+++ b/validators/subscription.validators.js
@@ -38,7 +38,7 @@ export const createSubscriptionValidators = [    body('name')
         .withMessage('Moneda no válida'),
 
     body('frequency')
-        .isIn(['mensual', 'trimestral', 'semestral', 'anual'])
+        .isIn(['diaria', 'semanal', 'mensual', 'anual'])
         .withMessage('Frecuencia no válida'),
 
     body('category')
@@ -121,7 +121,7 @@ export const updateSubscriptionValidators = [
 
     body('frequency')
         .optional()
-        .isIn(['mensual', 'trimestral', 'semestral', 'anual'])
+        .isIn(['diaria', 'semanal', 'mensual', 'anual'])
         .withMessage('Frecuencia no válida'),
 
     body('category')
@@ -211,7 +211,7 @@ export const queryValidators = [
 
     query('frequency')
         .optional()
-        .isIn(['mensual', 'trimestral', 'semestral', 'anual'])
+        .isIn(['diaria', 'semanal', 'mensual', 'anual'])
         .withMessage('Frecuencia no válida'),
 
     query('days')


### PR DESCRIPTION
## Summary
- align subscription validators with subscription model by using same frequency values
- remove unused import from tests

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ebeb3eec8325bc698bb37c91759b